### PR TITLE
- Put back 'email background color' property at main element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.0.11] - 2019.02.21
+### Fixed/Changed
+- Put back 'email background color' property at main element
+- Use mj-attributes for default mj-section color (same as main background color)
+- Use mj-attirbutes for default mj-section padding of 5px
+- Use mj-attirbutes for default mj-text padding of 5px
+- Removed hardcoded padding of 0px from row, column, vspacer and text
+- Do not put properties with falsy value as attributes of mj elements
+- In case mj-text is enclosed with mj-section, apply the mj-text's background color to the section
+- Automatically add an empty top section with 2px padding and 'email background color'
+- Automatically add an empty bottom section with 2px padding and 'email background color'
+
 ## [0.0.10] - 2019.02.21
 ### Added
 - Inline classes for text colors (fore- and back-) matching edie-color-p-XXXXXX and edie-color-m-XXXXXX 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed/Changed
 - Put back 'email background color' property at main element
 - Use mj-attributes for default mj-section color (same as main background color)
-- Use mj-attirbutes for default mj-section padding of 5px
-- Use mj-attirbutes for default mj-text padding of 5px
+- Use mj-attributes for default mj-section padding of 5px
+- Use mj-attributes for default mj-text padding of 5px
 - Removed hardcoded padding of 0px from row, column, vspacer and text
 - Do not put properties with falsy value as attributes of mj elements
 - In case mj-text is enclosed with mj-section, apply the mj-text's background color to the section
 - Automatically add an empty top section with 2px padding and 'email background color'
 - Automatically add an empty bottom section with 2px padding and 'email background color'
+- Removed hardcoded padding of 0px when creating empty element
 
 ## [0.0.10] - 2019.02.21
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edie-processors",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "A set of helper methods",
   "main": "./lib/index.js",
   "files": [

--- a/src/blocks/column.js
+++ b/src/blocks/column.js
@@ -6,9 +6,6 @@ const columnToMjml = (item, childrenRenderer) => {
     };
 
     let mjmlProperties = translateProps(item.properties, keyTranslations);
-    if (!mjmlProperties['padding']) {
-        mjmlProperties['padding'] = '0px';
-    }
     if (mjmlProperties['borderSize'] && mjmlProperties['borderColor']) {
         mjmlProperties['border'] = mjmlProperties['borderSize'] + ' solid ' + mjmlProperties['borderColor'];
     }

--- a/src/blocks/common/base.js
+++ b/src/blocks/common/base.js
@@ -27,7 +27,9 @@ const propertiesToText = (props, keysToIgnore) => {
         .filter((key) => !(keysToIgnore || []).includes(key))
         .forEach((key) => {
             // TODO FIX: Make sure props[key] is escaped !!!
-            properties = properties + ' ' + key + '="' + props[key] + '"';
+            if (props[key]) {
+                properties = properties + ' ' + key + '="' + props[key] + '"';
+            }
         });
     return properties;
 };

--- a/src/blocks/main.js
+++ b/src/blocks/main.js
@@ -5,11 +5,11 @@ import {vspacerToMjml} from './vspacer';
 
 const mainToMjml = (item, childrenRenderer) => {
     let keyTranslations = {
-        'backgroundColor': 'background-color',
+        'emailBackgroundColor': 'background-color',
         'emailWidth': 'width',
     };
 
-    let properties = propertiesToText(translateProps(item.properties, keyTranslations), ['emailBackgroundColor', 'isPublic']);
+    let properties = propertiesToText(translateProps(item.properties, keyTranslations), ['backgroundColor', 'isPublic']);
     let items = '';
     (item.children || []).forEach((x) => {
         switch (x.type) {
@@ -27,7 +27,11 @@ const mainToMjml = (item, childrenRenderer) => {
             break;
         }
     });
-    return `<mj-body ${properties}>${items}</mj-body>`;
+    return `<mj-body ${properties}>
+<mj-section background-color="${item.properties['emailBackgroundColor']}"><mj-column><mj-text padding="2px"></mj-text></mj-column></mj-section>
+${items}
+<mj-section background-color="${item.properties['emailBackgroundColor']}"><mj-column><mj-text padding="2px"></mj-text></mj-column></mj-section>
+</mj-body>`;
 };
 
 const mainTotext = (item, childrenRenderer) => {

--- a/src/blocks/row.js
+++ b/src/blocks/row.js
@@ -6,10 +6,6 @@ function rowToMjml(item, childrenRenderer) {
     };
 
     let mjmlProperties = translateProps(item.properties, keyTranslations);
-    mjmlProperties['full-width'] = 'full-width';
-    if (!mjmlProperties['padding']) {
-        mjmlProperties['padding'] = '0px';
-    }
 
     let properties = propertiesToText(mjmlProperties);
     let items = '';

--- a/src/blocks/text.js
+++ b/src/blocks/text.js
@@ -66,17 +66,13 @@ const textToMjml = (item, encloseInSection) => {
             backgroundColor: 'container-background-color',
         });
 
-    if (!mjmlProperties['padding']) {
-        mjmlProperties['padding'] = '0px';
-    }
-
     let properties = propertiesToText(mjmlProperties, ['content']);
 
     let mjText = `<mj-text ${properties}>${content}</mj-text>`;
 
     // mj-text NOT allowed in mj-body
     return encloseInSection
-        ? `<mj-section padding="0px"><mj-column padding="0px">${mjText}</mj-column></mj-section>`
+        ? `<mj-section ${propertiesToText({'background-color': item.properties.backgroundColor})}><mj-column>${mjText}</mj-column></mj-section>`
         : mjText;
 };
 

--- a/src/blocks/vspacer.js
+++ b/src/blocks/vspacer.js
@@ -13,7 +13,7 @@ const vspacerToMjml = (item, encloseInSection) => {
 
     // mj-spacer NOT allowed in mj-body
     return encloseInSection
-        ? `<mj-section padding="0px"><mj-column padding="0px">${mjSpacer}</mj-column></mj-section>`
+        ? `<mj-section ><mj-column >${mjSpacer}</mj-column></mj-section>`
         : mjSpacer;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -134,20 +134,17 @@ function createEmptyBlock(type) {
 
     case EDIE_BLOCK_TYPE.TEXT:
         props = {
-            padding: '0px',
         };
         break;
 
     case EDIE_BLOCK_TYPE.ROW:
         props = {
-            padding: '0px',
         };
         break;
 
     case EDIE_BLOCK_TYPE.COLUMN:
         props = {
             width: '100%',
-            padding: '0px',
         };
         break;
 

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,8 @@ function edie2hbsmjml(edieJson) {
         return 'Not supported version!';
     }
 
+    let defaultBackground = edieJson.structure.properties.backgroundColor || '#ffffff';
+
     let mjml = blockToMjml(edieJson.structure, blockToMjml);
     let colorClasses = extractColorClasses(mjml);
     let styles = '';
@@ -80,6 +82,10 @@ function edie2hbsmjml(edieJson) {
       figure.image.image-style-align-right img { max-width: 50%; float: right; margin-left: 1.5em; }
       ${styles}
     </mj-style>
+    <mj-attributes>
+        <mj-section background-color="${defaultBackground}" padding="5px"/>
+        <mj-text padding="5px"/>
+    </mj-attributes>
 </mj-head>
 ${mjml}
 </mjml>`;


### PR DESCRIPTION
- Use mj-attributes for default mj-section color (same as main background color)
- Use mj-attirbutes for default mj-section padding of 5px
- Use mj-attirbutes for default mj-text padding of 5px
- Removed hardcoded padding of 0px from row, column, vspacer and text
- Do not put properties with falsy value as attributes of mj elements
- In case mj-text is enclosed with mj-section, apply the mj-text's background color to the section
- Automatically add an empty top section with 2px padding and 'email background color'
- Automatically add an empty bottom section with 2px padding and 'email background color'