### PR TITLE
Add default values for image empty block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [0.0.13] - 2019.02.25
+### Changed
+- Changed default values for image empty block
+
+## [0.0.13] - 2019.02.25
 ### Added
 - Support for dynamic images (span type='dynamicImage')
 ### Fixed/Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "edie-processors",
-  "version": "0.0.12",
+  "version": "0.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edie-processors",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "A set of helper methods",
   "main": "./lib/index.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -168,7 +168,7 @@ function createEmptyBlock(type) {
             backgroundColor: '#ffffff',
             align: 'center',
             borderSize: '0px',
-            borderColor: '#ffffff'
+            borderColor: '#ffffff',
         };
         break;
 

--- a/src/index.js
+++ b/src/index.js
@@ -161,9 +161,14 @@ function createEmptyBlock(type) {
         break;
     case EDIE_BLOCK_TYPE.IMAGE:
         props = {
-            width: '100%',
+            width: '',
             src: '',
             alt: '',
+            href: '',
+            backgroundColor: '#ffffff',
+            align: 'center',
+            borderSize: '0px',
+            borderColor: '#ffffff'
         };
         break;
 


### PR DESCRIPTION
Note:
In `mj-image` if no width is provided the image takes 100% of the parent width.